### PR TITLE
Adding markdown files for MolSSI lesson resources

### DIFF
--- a/notebooks/Command_Line.md
+++ b/notebooks/Command_Line.md
@@ -1,0 +1,10 @@
+# Introduction to the Bash Shell
+The material for the `command line` lessons is adapted from the [MolSSI Introduction to the Command Line lessons](https://education.molssi.org/python-package-best-practices/00-command-line-basics.html).
+The lessons will cover
+- The `command line` interface to your computer.
+- How to view and move around your file system with the `command line`.
+- How to create and work with files from the `command line`
+
+We will utilize the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit) to create a repository and fill it with code from the MDAnalysis `mdgeomkit` repository developed for the workshop.
+
+The code can be found at https://github.com/MDAnalysis/mdgeomkit

--- a/notebooks/Documentation.md
+++ b/notebooks/Documentation.md
@@ -1,0 +1,10 @@
+# Documentation
+The material for the `documentation` lessons is adapted from the [MolSSI Package Documentation Lessons](https://education.molssi.org/python-package-best-practices/10-documentation.html).
+The lessons will cover
+- Types of documentation
+- Documenting your code through `docstrings`.
+- Creating documentation using [Sphinx](https://www.sphinx-doc.org/en/master/) and [readthedocs](https://about.readthedocs.com/?ref=readthedocs.org)
+
+We will utilize the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit) to create a repository and fill it with code from the MDAnalysis `mdgeomkit` repository developed for the workshop.
+
+The code can be found at https://github.com/MDAnalysis/mdgeomkit

--- a/notebooks/Python_Packaging.md
+++ b/notebooks/Python_Packaging.md
@@ -1,0 +1,10 @@
+# Python Packaging
+The material for the `python packaging` lessons is adapted from the [MolSSI Python Package Setup Lessons](https://education.molssi.org/python-package-best-practices/01-package-setup.html).
+The lessons will cover
+- The use of the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit)
+- The file structures produced by the `cookiecutter`.
+- How to develop and use a python package utilizing the `cookiecutter` output.
+
+We will utilize the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit) to create a repository and fill it with code from the MDAnalysis `mdgeomkit` repository developed for the workshop.
+
+The code can be found at https://github.com/MDAnalysis/mdgeomkit

--- a/notebooks/Testing.md
+++ b/notebooks/Testing.md
@@ -1,0 +1,10 @@
+# Python Testing
+The material for the `pytest` lessons is adapted from the [MolSSI Python Testing lessons](https://education.molssi.org/python-package-best-practices/08-testing.html).
+The lessons will cover the use of
+- `pytest` to write tests for functions.
+- `pytest` features such as fixtures and parameterization.
+- The coverage of the code based on written tests.
+
+We will utilize the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit) to create a repository and fill it with code from the MDAnalysis `mdgeomkit` repository developed for the workshop.
+
+The code can be found at https://github.com/MDAnalysis/mdgeomkit

--- a/notebooks/Version_Control.md
+++ b/notebooks/Version_Control.md
@@ -1,0 +1,10 @@
+# Git and GitHub
+The material for the `git` lessons is adapted from the [MolSSI git and GitHub Lessons](https://education.molssi.org/python-package-best-practices/00-git-and-github.html).
+The lessons will cover the use of
+- the `git` version control software.
+- [GitHub](https://github.com/), a remote hosting resource for `git` repositories.
+- Utilizing `GitHub` for collaboration on software projects, using a [Periodic Table Repository](https://github.com/MolSSI-Education/periodic-table), produced by MolSSI
+
+We will utilize the [MDAnalysis CookieCutter](https://github.com/MDAnalysis/cookiecutter-mdakit) to create a repository and fill it with code from the MDAnalysis `mdgeomkit` repository developed for the workshop.
+
+The code can be found at https://github.com/MDAnalysis/mdgeomkit


### PR DESCRIPTION
I have created a set of markdown files with relevant links for the MolSSI lessons.
Each one points to the associated Molssi lesson, the MDAnalysis Cookiecutter, and the `mdgeomkit` repository as a link for the code.
I have currently placed them in notebooks, but if you would prefer them to live somewhere else let me know.
Once merged, I can update the links in the schedule.