### PR TITLE
Add installer

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -1,0 +1,45 @@
+name: Make single-file installers
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+jobs:
+  test:
+    name: Building single file installer on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-12, ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Install constructor environment with Micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: installer
+        create-args: >-
+          python=3.10
+          jinja2
+          constructor
+        init-shell: bash
+
+    - name: Create installer
+      run: constructor .
+
+    - name: Upload openfe forge to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: mda_workshop-jun24-ws-*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true
+        prerelease: true
+        tag: 1.0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -410,7 +410,7 @@ Section 8 -- Interpretation.
 Creative Commons is not a party to its public
 licenses. Notwithstanding, Creative Commons may elect to apply one of
 its public licenses to material it publishes and in those instances
-will be considered the “Licensor.” The text of the Creative Commons
+will be considered the "Licensor." The text of the Creative Commons
 public licenses is dedicated to the public domain under the CC0 Public
 Domain Dedication. Except for the limited purpose of indicating that
 material is shared under a Creative Commons public license or as

--- a/construct.yaml
+++ b/construct.yaml
@@ -1,0 +1,56 @@
+{% set version = os.environ.get("MINIFORGE_VERSION", "24.3.0-0") %}
+{% set conda_libmamba_solver_version = "24.1.0"%}
+{% set mamba_version = "1.5.8"%}
+
+name: mda_workshop
+version: jun24-ws
+company: MDAnalysis
+
+channels:
+  - conda-forge
+
+write_condarc: True
+# keep pkgs for space-saving implications for hardlinks when create new environments
+# and keep the same with Miniconda
+keep_pkgs: True
+license_file: LICENSE.md
+
+# During the interactive installation, these variables are checked.
+# During batch installation, conda is never initialized
+initialize_conda: True
+initialize_by_default: False
+
+user_requested_specs:
+  - python 3.10.*
+  - pip
+  - conda >={{ version.split("-")[0] }}
+  # Omit conda-libmamba-solver so that conda is free to remove it later
+  - mamba >={{ mamba_version }}
+  - miniforge_console_shortcut 1.*  # [win]
+
+specs:
+  - python 3.10.*
+  - conda {{ version.split("-")[0] }}
+  - conda-libmamba-solver {{ conda_libmamba_solver_version }}
+  - mamba {{ mamba_version }}
+
+  - pip
+  - miniforge_console_shortcut 1.*  # [win]
+
+  - MDAnalysis
+  - MDAnalysisTests
+  - MDAnalysisData
+  - cookiecutter
+  - nglview==3.0.3
+  - notebook<7
+  - jupyter_contrib_nbextensions
+  - importlib-metadata
+  - rdkit
+  # For sphinx
+  - mdanalysis-sphinx-theme >=1.0.1
+  # For prsentations
+  - rise
+  # testing
+  - pytest
+  - nbval
+  - ipywidgets==7.6.0


### PR DESCRIPTION
This PR will enable on demand building of a single file installer.

Some notes:

- The installers will be uploaded/attached to the "1.0" release of the repo, we need a place to put them that is easy to find (IMHO)
- I did a copy and paste job for the installer spec from the envrionment.yaml file in the repo, there are ways to keep this in sync but I thought the overhead of that would be harder to maintain
- I've only tested the linux installer locally

Let me know if you have any questions! I hope that I can run these as a test without merging but if we can't, then we should just merge this in and then I can iterate/fix things as we get errors.

I also realized I made this branch on my fork instead of the repo proper, so it might need to be merged in before it can be tested.