### PR TITLE
Update UG and docs links to "stable"

### DIFF
--- a/notebooks/Lecture1_MDAnalysisBasics_TheUniverse.ipynb
+++ b/notebooks/Lecture1_MDAnalysisBasics_TheUniverse.ipynb
@@ -178,7 +178,7 @@
     "\n",
     "Note that some files can double as both a *topology* and a *trajectory*.  \n",
     "\n",
-    "MDanalysis supports [over 40 input file types](https://userguide.mdanalysis.org/2.0.0-dev0/formats/index.html#formats)"
+    "MDanalysis supports [over 40 input file types](https://userguide.mdanalysis.org/stable/formats/index.html#formats)"
    ]
   },
   {

--- a/notebooks/Tutorial1_System_Manipulation.ipynb
+++ b/notebooks/Tutorial1_System_Manipulation.ipynb
@@ -98,7 +98,7 @@
     "\n",
     "### Additional resources\n",
     " - During the workshop, feel free to ask questions at any time\n",
-    " - For more on how to use MDAnalysis, see the [User Guide](https://userguide.mdanalysis.org/2.0.0-dev0/) and [documentation](https://docs.mdanalysis.org/2.0.0-dev0/)\n",
+    " - For more on how to use MDAnalysis, see the [User Guide](https://userguide.mdanalysis.org/stable/) and [documentation](https://docs.mdanalysis.org/stable/)\n",
     " - Ask questions on the [GitHub Discussions forum](https://github.com/MDAnalysis/mdanalysis/discussions) or on [Discord](https://discord.gg/fXTSfDJyxE)\n",
     " - Report bugs on [GitHub](https://github.com/MDAnalysis/mdanalysis/issues?)"
    ]
@@ -167,7 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To make a `Universe`, we need at the very least a topology file - see the [topology readers](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/topology/init.html) documentation for a list of supported file formats. \n",
+    "To make a `Universe`, we need at the very least a topology file - see the [topology readers](https://docs.mdanalysis.org/stable/documentation_pages/topology/init.html) documentation for a list of supported file formats. \n",
     "\n",
     "Since the type of topology file we're using in this example (a PSF file) doesn't contain coordinates, we'll also need to load a trajectory file (in this case a DCD file) so we have some position data to work with later. You'll learn more about working with trajectories in the next session. \n"
    ]
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, `MDAnalysis` will try and extract as much information as possible from the files given to `Universe`. The [topology readers](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/topology/init.html) documentation lists the attributes that are extracted from each filetype."
+    "In general, `MDAnalysis` will try and extract as much information as possible from the files given to `Universe`. The [topology readers](https://docs.mdanalysis.org/stable/documentation_pages/topology/init.html) documentation lists the attributes that are extracted from each filetype."
    ]
   },
   {
@@ -652,7 +652,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also see them in the docs [here](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html).\n",
+    "You can also see them in the docs [here](https://docs.mdanalysis.org/stable/documentation_pages/selections.html).\n",
     "\n",
     "Although boolean selections work well enough for selecting out atoms from AtomGroups, the selection language makes more complex selections possible with probably less effort.\n",
     "\n",
@@ -1033,7 +1033,7 @@
     "\n",
     "Select all hydrogens that are bonded to an alpha carbon\n",
     "\n",
-    "*Hint: Look through the `select_atoms` docstring above or [here](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html) for keywords that might help!*"
+    "*Hint: Look through the `select_atoms` docstring above or [here](https://docs.mdanalysis.org/stable/documentation_pages/selections.html) for keywords that might help!*"
    ]
   },
   {
@@ -1738,7 +1738,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- If you haven't already, read through the [selection documentation](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/selections.html) and play around with all the selection options not covered above\n",
+    "- If you haven't already, read through the [selection documentation](https://docs.mdanalysis.org/stable/documentation_pages/selections.html) and play around with all the selection options not covered above\n",
     "\n",
     "\n",
     "- [nglview](https://github.com/nglviewer/nglview#usage) has a lot of visualisation options - you can add multiple selections to one view, change their colour and representation style and more - look through their documentaiton and see what you can create!"

--- a/notebooks/Tutorial2_Trajectories.ipynb
+++ b/notebooks/Tutorial2_Trajectories.ipynb
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This `trajectory` object has a length in `frames` and a time unit of **picoseconds** (more information about the [MDAnalysis base units](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/units.html#id4) is in the docs).\n",
+    "This `trajectory` object has a length in `frames` and a time unit of **picoseconds** (more information about the [MDAnalysis base units](https://docs.mdanalysis.org/stable/documentation_pages/units.html#id4) is in the docs).\n",
     "\n",
     "The `trajectory` object has many useful attributes, such as the the number of frames `n_frames`, the time between frames `dt`, the total trajectory time `totaltime`."
    ]
@@ -290,7 +290,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's also possible to load / concatenate multiple trajectories together in one go using MDAnalysis' [ChainReader](https://docs.mdanalysis.org/2.0.0-dev0/documentation_pages/coordinates/chain.html?highlight=chainreader#chainreader-mdanalysis-coordinates-chain).\n",
+    "It's also possible to load / concatenate multiple trajectories together in one go using MDAnalysis' [ChainReader](https://docs.mdanalysis.org/stable/documentation_pages/coordinates/chain.html?highlight=chainreader#chainreader-mdanalysis-coordinates-chain).\n",
     "\n",
     "This can be done simply by passing several trajectories to the Universe when creating the object."
    ]


### PR DESCRIPTION
Many links in Lectures/Tutorials 1 & 2 were previously pointing to the 2.0 versions of the UG and docs - I've updated the links such that they point to the stable versions instead.